### PR TITLE
Remove platform-dependent event interface import

### DIFF
--- a/server/convergence-collect.py
+++ b/server/convergence-collect.py
@@ -23,8 +23,18 @@ USA
 
 """
 
-from twisted.internet import epollreactor
-epollreactor.install()
+# BSD and Mac OS X, kqueue
+try:
+    from twisted.internet import kqreactor as event_reactor
+except:
+    # Linux 2.6 and newer, epoll
+    try:
+        from twisted.internet import epollreactor as event_reactor
+    except:
+        # Linux pre-2.6, poll
+        from twisted.internet import pollreactor as event_reactor
+
+event_reactor.install()
 
 from twisted.enterprise import adbapi
 from twisted.internet import reactor

--- a/server/convergence-notary.py
+++ b/server/convergence-notary.py
@@ -23,8 +23,18 @@ USA
 
 """
 
-from twisted.internet import epollreactor
-epollreactor.install()
+# BSD and Mac OS X, kqueue
+try:
+    from twisted.internet import kqreactor as event_reactor
+except:
+    # Linux 2.6 and newer, epoll
+    try:
+        from twisted.internet import epollreactor as event_reactor
+    except:
+        # Linux pre-2.6, poll
+        from twisted.internet import pollreactor as event_reactor
+
+event_reactor.install()
 
 from convergence.TargetPage import TargetPage
 from convergence.ConnectChannel import ConnectChannel


### PR DESCRIPTION
OSX/BSD use kqueue; older Linux may only have poll available. The import
sequence tries to get the best interface for the given platform, since
Twisted supports all the various options already.
