### PR TITLE
createdb.py included with the rest of the setup scripts + fixed cleanup stage

### DIFF
--- a/server/convergence-collect.py
+++ b/server/convergence-collect.py
@@ -23,8 +23,18 @@ USA
 
 """
 
-from twisted.internet import epollreactor
-epollreactor.install()
+# BSD and Mac OS X, kqueue
+try:
+    from twisted.internet import kqreactor as event_reactor
+except:
+    # Linux 2.6 and newer, epoll
+    try:
+        from twisted.internet import epollreactor as event_reactor
+    except:
+        # Linux pre-2.6, poll
+        from twisted.internet import pollreactor as event_reactor
+
+event_reactor.install()
 
 from twisted.enterprise import adbapi
 from twisted.internet import reactor

--- a/server/convergence-notary.py
+++ b/server/convergence-notary.py
@@ -23,8 +23,18 @@ USA
 
 """
 
-from twisted.internet import epollreactor
-epollreactor.install()
+# BSD and Mac OS X, kqueue
+try:
+    from twisted.internet import kqreactor as event_reactor
+except:
+    # Linux 2.6 and newer, epoll
+    try:
+        from twisted.internet import epollreactor as event_reactor
+    except:
+        # Linux pre-2.6, poll
+        from twisted.internet import pollreactor as event_reactor
+
+event_reactor.install()
 
 from convergence.TargetPage import TargetPage
 from convergence.ConnectChannel import ConnectChannel

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,10 +1,17 @@
 import os, shutil
 from distutils.core import setup, Extension
 
-shutil.copyfile("convergence-notary.py", "convergence/convergence-notary")
-shutil.copyfile("convergence-gencert.py", "convergence/convergence-gencert")
-shutil.copyfile("convergence-createdb.py", "convergence/convergence-createdb")
-shutil.copyfile("convergence-bundle.py", "convergence/convergence-bundle")
+# Name of convergence directory
+DIR = "convergence"
+# List of scripts to install
+SCRIPTS = ["convergence-notary",
+            "convergence-gencert",
+            "convergence-createdb",
+            "convergence-bundle"]
+
+# Copy and rename python scripts
+for s in SCRIPTS:
+    shutil.copyfile(s + ".py", os.path.join(DIR, s))
 
 setup  (name        = 'convergence-notary',
         version     = '0.01',
@@ -15,7 +22,7 @@ setup  (name        = 'convergence-notary',
         license = 'GPL',
         packages  = ["convergence"],
         package_dir = {'convergence' : 'convergence/'},
-        scripts = ['convergence/convergence-notary', 'convergence/convergence-gencert', 'convergence/convergence-createdb', 'convergence/convergence-bundle'],
+        scripts = [os.path.join(DIR, s) for s in SCRIPTS],
         data_files = [('share/convergence', ['README', 'INSTALL', 'COPYING']),
                       ('/etc/init.d', ['init-script/convergence'])]
        )
@@ -24,13 +31,12 @@ print "Cleaning up..."
 if os.path.exists("build/"):
     shutil.rmtree("build/")
 
-try:
-    os.remove("convergence/convergence-notary")
-    os.remove("convergence/convergence-bundle")
-    os.remove('convergence/convergence-createdb')
-    os.remove("convergence/convergence-gencert")
-except:
-    pass
+# remove renamed scripts from temporary location
+for s in SCRIPTS:
+    try:
+        os.remove(os.path.join(DIR, s))
+    except:
+        pass
 
 def capture(cmd):
     return os.popen(cmd).read().strip()

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,4 +1,4 @@
-import sys, os, shutil
+import os, shutil
 from distutils.core import setup, Extension
 
 shutil.copyfile("convergence-notary.py", "convergence/convergence-notary")
@@ -21,43 +21,16 @@ setup  (name        = 'convergence-notary',
        )
 
 print "Cleaning up..."
-
-try:
-    removeall("build/")
-    os.rmdir("build/")
-except:
-    pass
+if os.path.exists("build/"):
+    shutil.rmtree("build/")
 
 try:
     os.remove("convergence/convergence-notary")
     os.remove("convergence/convergence-bundle")
     os.remove('convergence/convergence-createdb')
     os.remove("convergence/convergence-gencert")
-
 except:
     pass
 
 def capture(cmd):
     return os.popen(cmd).read().strip()
-
-def removeall(path):
-	if not os.path.isdir(path):
-		return
-
-	files=os.listdir(path)
-
-	for x in files:
-		fullpath=os.path.join(path, x)
-		if os.path.isfile(fullpath):
-			f=os.remove
-			rmgeneric(fullpath, f)
-		elif os.path.isdir(fullpath):
-			removeall(fullpath)
-			f=os.rmdir
-			rmgeneric(fullpath, f)
-
-def rmgeneric(path, __func__):
-	try:
-		__func__(path)
-	except OSError, (errno, strerror):
-		pass

--- a/server/setup.py
+++ b/server/setup.py
@@ -3,6 +3,7 @@ from distutils.core import setup, Extension
 
 shutil.copyfile("convergence-notary.py", "convergence/convergence-notary")
 shutil.copyfile("convergence-gencert.py", "convergence/convergence-gencert")
+shutil.copyfile("convergence-createdb.py", "convergence/convergence-createdb")
 shutil.copyfile("convergence-bundle.py", "convergence/convergence-bundle")
 
 setup  (name        = 'convergence-notary',
@@ -14,7 +15,7 @@ setup  (name        = 'convergence-notary',
         license = 'GPL',
         packages  = ["convergence"],
         package_dir = {'convergence' : 'convergence/'},
-        scripts = ['convergence/convergence-notary', 'convergence/convergence-gencert', 'convergence/convergence-bundle'],
+        scripts = ['convergence/convergence-notary', 'convergence/convergence-gencert', 'convergence/convergence-createdb', 'convergence/convergence-bundle'],
         data_files = [('share/convergence', ['README', 'INSTALL', 'COPYING']),
                       ('/etc/init.d', ['init-script/convergence'])]
        )
@@ -30,6 +31,7 @@ except:
 try:
     os.remove("convergence/convergence-notary")
     os.remove("convergence/convergence-bundle")
+    os.remove('convergence/convergence-createdb')
     os.remove("convergence/convergence-gencert")
 
 except:


### PR DESCRIPTION
1. add `convergence-createdb.py` to the list of scripts to process during install
2. fix cleanup stage
3. keep all script names in a Python list and use from there as needed; easier to extend if needed
