### PR TITLE
source /etc/default/convergence from the init-script

### DIFF
--- a/server/init-script/convergence
+++ b/server/init-script/convergence
@@ -51,6 +51,8 @@ NICE=""
 
 test -x $DAEMON || exit 0
 
+test -f /etc/default/$NAME && . /etc/default/$NAME
+
 wait_for_deaddaemon () {
 	pid=$1
 	sleep 1


### PR DESCRIPTION
handy to override defaults, for instance:

```
ARGS="-c /.../my.pem -k /.../my.key"
```
