### PR TITLE
simplejson instead of json for python-2.5 compatibility

### DIFF
--- a/server/convergence/NotaryResponse.py
+++ b/server/convergence/NotaryResponse.py
@@ -16,7 +16,7 @@
 # USA
 #
 
-import hashlib, json, base64, logging
+import hashlib, simplejson as json, base64, logging
 from M2Crypto import BIO, RSA
 
 # This class is responsible for formatting verification response

--- a/server/convergence/TargetPage.py
+++ b/server/convergence/TargetPage.py
@@ -16,7 +16,7 @@
 # USA
 #
 
-import hashlib, json, base64, logging
+import hashlib, simplejson as json, base64, logging
 from M2Crypto import BIO, RSA
 
 from twisted.web.resource import Resource


### PR DESCRIPTION
Use simplejson instead of json, it's faster then json and works with python-2.5 (and maybe 2.4)
