### PR TITLE
Generalize Google verifier to DNS verifier.

### DIFF
--- a/server/convergence-notary.py
+++ b/server/convergence-notary.py
@@ -46,7 +46,7 @@ from convergence.ConnectChannel import ConnectChannel
 from convergence.ConnectRequest import ConnectRequest
 
 from convergence.verifier.NetworkPerspectiveVerifier import NetworkPerspectiveVerifier
-from convergence.verifier.GoogleCatalogVerifier import GoogleCatalogVerifier
+from convergence.verifier.DNSVerifier import DNSVerifier
 
 from OpenSSL import SSL
 from twisted.enterprise import adbapi
@@ -132,16 +132,16 @@ def usage():
     print "-k <key>       SSL private key location."
     print "-u <username>  Name of user to drop privileges to (defaults to 'nobody')"
     print "-g <group>     Name of group to drop privileges to (defaults to 'nogroup')"
-    print "-b <backend>   Verifier backend [perspective|google] (defaults to 'perspective')"
+    print "-b <backend>   Verifier backend [perspective|dns:host] (defaults to 'perspective')"
     print "-f             Run in foreground."
     print "-d             Debug mode."
     print "-h             Print this help message."
     print ""
 
 def initializeBackend(backend):
-    if   (backend == "perspective"): return NetworkPerspectiveVerifier()
-    elif (backend == "google"):      return GoogleCatalogVerifier()
-    else:                            raise getopt.GetoptError("Invalid backend: " + backend)
+    if   (backend == "perspective"):   return NetworkPerspectiveVerifier()
+    elif (backend.startswith("dns:")): return DNSVerifier(backend.split(":")[1])
+    else:                              raise getopt.GetoptError("Invalid backend: " + backend)
     
 def checkPrivileges(userName, groupName):                
     try:

--- a/server/convergence/verifier/DNSVerifier.py
+++ b/server/convergence/verifier/DNSVerifier.py
@@ -21,16 +21,15 @@ import logging
 
 from Verifier import Verifier
 
-class GoogleCatalogVerifier(Verifier):
+class DNSVerifier(Verifier):
     """
     This class is responsible for checking a certificate fingerprint
-    in the Google Certificate Catalog.
+    via a DNS-based certificate catalog
     """
 
-    CATALOG_HOST = "certs.googlednstest.com"
-    
-    def __init__(self):
+    def __init__(self, host):
         Verifier.__init__(self)
+        self.host = host
 
     def _dnsLookupComplete(self, result, fingerprint):
         logging.debug("Catalog result: " + str(result[0][0].payload.data[0]))
@@ -42,7 +41,7 @@ class GoogleCatalogVerifier(Verifier):
 
     def verify(self, host, port, fingerprint):
         formatted = "".join(fingerprint.split(":")).lower()
-        deferred  = twisted.names.client.lookupText("%s.%s" % (formatted, self.CATALOG_HOST))
+        deferred  = twisted.names.client.lookupText("%s.%s" % (formatted, self.host))
 
         deferred.addCallback(self._dnsLookupComplete, fingerprint)
         deferred.addErrback(self._dnsLookupError)


### PR DESCRIPTION
Google's Certificate Catalog seems to be defunct. This commit replaces the Google-specific Verifier with a more generic DNS-based verifier. From a user perspective, one can now provide the DNS hostname of the verifier to use on the command line, e.g.:

```
convergence-notary.py -b dns:your.catalog.here.com
```

The DNS catalog must accept TXT lookups for hashes, such as:

   1956DC8A7DFB2A5A56934DA09778E3A11023358.your.notary.here.com

Answers should be compatbile to Google Certificate catalog API.
