### PR TITLE
Fix client hangs

### DIFF
--- a/client/chrome/content/http/HttpParser.js
+++ b/client/chrome/content/http/HttpParser.js
@@ -71,10 +71,23 @@ HttpParser.prototype.parseResponseCode = function(response) {
 HttpParser.prototype.readFully = function(socket) {
   var response = "";
   var buf      = null;
+  var length   = null;
 
-  while ((buf = socket.readString()) != null) {
-    response += buf;
-    dump("Read: " + buf + "\n");
+  while ((buf = socket.readString(length)) != null) {
+    response += buff;
+
+    // Try to limit reads according to content-length header
+    if (length != null) length -= buff.length;
+    else {
+      var headers_end = response.indexOf('\r\n\r\n');
+      if (headers_end != -1) {
+        var match = /(^|\r\n)content-length:\s+(\d+)\r\n/i
+          .exec(response.substring(0, headers_end+2));
+        if (match) {
+          length = (headers_end + 4 + parseInt(match[2])) - response.length;
+        }
+      }
+    }
   }
 
   return response;

--- a/client/chrome/content/sockets/ConvergenceNotarySocket.js
+++ b/client/chrome/content/sockets/ConvergenceNotarySocket.js
@@ -21,8 +21,8 @@ ConvergenceNotarySocket.prototype.writeBytes = function(buffer, length) {
   return this.connection.writeBytes(buffer, length);
 };
 
-ConvergenceNotarySocket.prototype.readString = function() {
-  return this.connection.readString();
+ConvergenceNotarySocket.prototype.readString = function(length) {
+  return this.connection.readString(length);
 };
 
 ConvergenceNotarySocket.prototype.readFully = function(length) {

--- a/server/convergence/NotaryResponse.py
+++ b/server/convergence/NotaryResponse.py
@@ -40,9 +40,6 @@ class NotaryResponse:
         return json.dumps(response)
 
     def sendResponse(self, code, recordRows):
-        self.request.setHeader("Content-Type", "application/json")
-        self.request.setResponseCode(code)
-
         fingerprintList = []
 
         if recordRows is not None:
@@ -52,9 +49,12 @@ class NotaryResponse:
                                'timestamp' : timestamp }
 
                 fingerprintList.append(fingerprint)
+        result = self.signResponse({'fingerprintList' : fingerprintList})
 
-        result = {'fingerprintList' : fingerprintList}
+        self.request.setHeader('Content-Type', 'application/json')
+        self.request.setHeader('Content-Length', str(len(result)))
+        self.request.setResponseCode(code)
 
-        self.request.write(self.signResponse(result))
+        self.request.write(result)
         self.request.finish()        
         


### PR DESCRIPTION
I didn't confirm it, but I suppose older twisted closed connections as soon as response was sent, which doesn't seem to be the case any longer, so convergence hangs for a long time polling for more data after receiving a complete reply.

These commits make notary code send Content-Length header and client code respect it.

Fix from #170 might still be necessary for the whole thing to work.
