### PR TITLE
Fix display of cached fingerprint dates

### DIFF
--- a/client/chrome/content/ssl/NativeCertificateCache.js
+++ b/client/chrome/content/ssl/NativeCertificateCache.js
@@ -171,7 +171,7 @@ NativeCertificateCache.prototype.fetchAll = function(sortColumn, sortDirection) 
       id: SQLITE.lib.sqlite3_column_int64(preparedStatement, 0),
       location: SQLITE.lib.sqlite3_column_text(preparedStatement, 1).readString(),
       fingerprint: SQLITE.lib.sqlite3_column_text(preparedStatement, 2).readString(),
-      timestamp: new Date(SQLITE.lib.sqlite3_column_int64(preparedStatement, 3)),
+      timestamp: new Date(parseInt(SQLITE.lib.sqlite3_column_int64(preparedStatement, 3))),
     });
   }
 


### PR DESCRIPTION
Firefox 19 displays these as "NaN-NaN-NaN NaN:NaN:NaN" because it fails to convert sqlite's int64 to js integer upon instantiation of Date object, producing "Invalid Date" and NaN's for all of its components.

Fix simply adds explicit parseInt() wrapping for timestamp field in query results.
